### PR TITLE
Journal Entry Editing

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -14,7 +14,9 @@ angular.module('starter.controllers', [])
     $scope.modal = modal;
   });
 
-  $scope.showEntryModal = function() {
+  $scope.showEntryModal = function(entry) {
+    // Allow use of modal for adding or updating entries
+    $scope.entry = entry || {}
     $scope.modal.show();
   };
 
@@ -23,7 +25,12 @@ angular.module('starter.controllers', [])
     // Make sure we have form data, then hide/save/clear form
     if (angular.isDefined(entry.title) && angular.isDefined(entry.content)) {
       $scope.modal.hide();
-      Journal.add(entry);
+      if (angular.isDefined(entry.id)) {
+        Journal.update(entry);
+      }
+      else {
+        Journal.add(entry);
+      };
       $scope.entry = {};
     }
     // Don't allow an incomplete form!

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -49,6 +49,7 @@ angular.module('starter.controllers', [])
   $scope.cancelEntryModal = function() {
     $scope.modal.hide();
     $scope.entry = {};
+    $scope.journal = Journal.refresh();
   };
 
   $scope.remove = function(entry) {

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -23,7 +23,7 @@ angular.module('starter.controllers', [])
   $scope.closeEntryModal = function(entry) {
 
     // Make sure we have form data, then hide/save/clear form
-    if (angular.isDefined(entry.title) && angular.isDefined(entry.content)) {
+    if (angular.isDefined(entry.title) && entry.title.length && angular.isDefined(entry.content) && entry.content.length) {
       $scope.modal.hide();
       if (angular.isDefined(entry.id)) {
         Journal.update(entry);

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -41,6 +41,15 @@ angular.module('starter.services', [])
       entry.id = journal[journal.length - 1].id + 1
       journal.push(entry);
       save();
+    },
+    update: function(entry) {
+      for (var i = 0; i < journal.length; i++) {
+        if (journal[i].id == entry.id) {
+          journal[i] = entry;
+          save();
+        }
+      }
+      return null;
     }
   };
 })

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -11,12 +11,18 @@ angular.module('starter.services', [])
   ];
 
   // If we have a journal object, use that!
-  if (localStorage.journal)
-    journal = JSON.parse(localStorage.journal);
+  // Added to function for use at both initialization
+  // and later to be able to refresh the journal
+  var loadJournal = function() {
+    if (localStorage.journal)
+      journal = JSON.parse(localStorage.journal);
+  };
 
   var save = function() {
     localStorage.journal = JSON.stringify(journal);
   };
+
+  loadJournal();
 
   return {
     all: function() {
@@ -50,6 +56,10 @@ angular.module('starter.services', [])
         }
       }
       return null;
+    },
+    refresh: function() {
+      loadJournal();
+      return journal;
     }
   };
 })

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -4,6 +4,7 @@ angular.module('starter.services', [])
   // Give us an example object
   var journal = [
     {
+      "id": 1,
       "title": "My 1st Entry",
       "content": "This is a sample entry."
     }
@@ -34,6 +35,10 @@ angular.module('starter.services', [])
       return null;
     },
     add: function(entry) {
+      // Assumes entries are ordered by id (asc) and
+      // will reuse ids when last entries are removed,
+      // but at least addresses duplicates and removal
+      entry.id = journal[journal.length - 1].id + 1
       journal.push(entry);
       save();
     }

--- a/www/templates/modals/entry.html
+++ b/www/templates/modals/entry.html
@@ -1,6 +1,6 @@
 <div class="modal">
     <ion-header-bar>
-        <h1 class="title">Add Entry</h1>
+        <h1 class="title">{{entry.id ? 'Update' : 'Add'}} Entry</h1>
     </ion-header-bar>
 
     <ion-content has-bouncing="false">
@@ -21,6 +21,6 @@
                 <button class="button button-full button-royal" ng-click="closeEntryModal(entry)">Done</button>
             </div>
         </div>
-        
+
     </ion-content>
 </div>

--- a/www/templates/tab-journal.html
+++ b/www/templates/tab-journal.html
@@ -7,7 +7,7 @@
   <ion-content class="padding">
 
     <ion-list>
-        <ion-item class="item-remove-animate item-icon-right" ng-repeat="entry in journal track by entry.id" type="item-text-wrap">
+        <ion-item class="item-remove-animate item-icon-right" ng-repeat="entry in journal track by entry.id" type="item-text-wrap" ng-click="showEntryModal(entry)">
             <h2>{{entry.title}}</h2>
             <p>{{entry.content}}</p>
             <i class="icon ion-chevron-right icon-accessory"></i>

--- a/www/templates/tab-journal.html
+++ b/www/templates/tab-journal.html
@@ -1,5 +1,5 @@
 <ion-view view-title="Journal">
-    
+
     <ion-nav-buttons side="right">
         <button class="button button-clear icon ion-ios-plus-outline" ng-click="showEntryModal()"></button>
     </ion-nav-buttons>
@@ -7,7 +7,7 @@
   <ion-content class="padding">
 
     <ion-list>
-        <ion-item class="item-remove-animate item-icon-right" ng-repeat="entry in journal track by entry.title" type="item-text-wrap">
+        <ion-item class="item-remove-animate item-icon-right" ng-repeat="entry in journal track by entry.id" type="item-text-wrap">
             <h2>{{entry.title}}</h2>
             <p>{{entry.content}}</p>
             <i class="icon ion-chevron-right icon-accessory"></i>


### PR DESCRIPTION
- The existing entry validation would not have actually required title/content to be present if text is entered and then deleted, either for new entries or for existing ones, but adding `.length` checks for both fields addresses this.
- When updating an entry and then cancelling out, even unsaved changes were reflected back in the journal until it was reloaded. To address this, the journal currently reloads from local storage (if it exists) whenever changes are cancelled; reloading the entire journal to reset a single entry seems like it might not be the best way to handle this, however.
